### PR TITLE
Add initial CRD validation

### DIFF
--- a/manifests/crd-alert.yml
+++ b/manifests/crd-alert.yml
@@ -1,3 +1,21 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This custom type definition is used to represent a firing alert.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -11,3 +29,12 @@ spec:
     singular: alert
     plural: alerts
   scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        status:
+          properties:
+            annotations:
+              type: object
+            labels:
+              type: object

--- a/manifests/crd-alerting-rule.yml
+++ b/manifests/crd-alerting-rule.yml
@@ -1,3 +1,23 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This custom type definition is used to represent an alerting rule, with a
+# syntax almost identical to the syntax used in the Prometheus configuration
+# files.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -11,3 +31,25 @@ spec:
     singular: alertingrule
     plural: alertingrules
   scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            group:
+              type: string
+            alert:
+              type: string
+            expr:
+              type: string
+            for:
+              type: string
+              pattern: '^(\d+h)?(\d+m)?(\d+s)?(\d+ms)?(\d+us)?(\d+ns)?$'
+            annotations:
+              type: object
+            labels:
+              type: object
+          required:
+          - group
+          - alert
+          - expr

--- a/manifests/crd-healing-rule.yml
+++ b/manifests/crd-healing-rule.yml
@@ -1,3 +1,21 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This custom type definition is used to represent healing rules.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -11,3 +29,47 @@ spec:
     singular: healingrule
     plural: healingrules
   scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            conditions:
+              type: array
+              minItems: 1
+              items:
+                type: object
+                oneOf:
+                - properties:
+                    alert:
+                      type: string
+                  required:
+                  - alert
+            actions:
+              type: array
+              minItems: 1
+              items:
+                type: object
+                oneOf:
+                - properties:
+                    awxJob:
+                      type: object
+                      properties:
+                        address:
+                          type: string
+                        proxy:
+                          type: string
+                        secret:
+                          type: string
+                        project:
+                          type: string
+                        template:
+                          type: string
+                      required:
+                      - address
+                      - secret
+                      - project
+                      - template
+          required:
+          - conditions
+          - actions


### PR DESCRIPTION
Currently the custom resource definitions used by the project aren't
validated at all. This patch introduces validation using the JSON schema
support that was added (still in beta) in Kubernetes 1.9. In previous
versions of Kubernetes the validation instructions will just be ignored.