### PR TITLE
Large user id crashes docker

### DIFF
--- a/images/alert-healer/Dockerfile.in
+++ b/images/alert-healer/Dockerfile.in
@@ -19,7 +19,7 @@ FROM centos:7
 # Create the monitoring user. The unusually high UID is needed because
 # recent versions of Kubernetes don't allow lower UID numbers.
 RUN \
-useradd -u 1000000000 -M monitoring
+useradd -l -u 1000000000 -M monitoring
 
 # Install the alert healer binary:
 COPY alert-healer /tmp

--- a/images/alert-manager/Dockerfile.in
+++ b/images/alert-manager/Dockerfile.in
@@ -19,7 +19,7 @@ FROM centos:7
 # Create the monitoring user. The unusually high UID is needed because
 # recent versions of Kubernetes don't allow lower UID numbers.
 RUN \
-useradd -u 1000000000 -M monitoring
+useradd -l -u 1000000000 -M monitoring
 
 # Install the alert manager binary:
 COPY alertmanager.tar.gz /tmp

--- a/images/alert-publisher/Dockerfile.in
+++ b/images/alert-publisher/Dockerfile.in
@@ -19,7 +19,7 @@ FROM centos:7
 # Create the monitoring user. The unusually high UID is needed because
 # recent versions of Kubernetes don't allow lower UID numbers.
 RUN \
-useradd -u 1000000000 -M monitoring
+useradd -l -u 1000000000 -M monitoring
 
 # Install the alert publisher binary:
 COPY alert-publisher /tmp

--- a/images/metrics-collector/Dockerfile.in
+++ b/images/metrics-collector/Dockerfile.in
@@ -19,7 +19,7 @@ FROM centos:7
 # Create the monitoring user. The unusually high UID is needed because
 # recent versions of Kubernetes don't allow lower UID numbers.
 RUN \
-useradd -u 1000000000 -M monitoring
+useradd -l -u 1000000000 -M monitoring
 
 # Install the Prometheus binary:
 COPY prometheus.tar.gz /tmp


### PR DESCRIPTION
When building the docker images large uid in `useradd` command causes docker to hang/crash. This patch fixes this phenomena.
(See: https://github.com/moby/moby/issues/5419)

cc: @jhernand 