### PR TITLE
Make alert name unique and resolve them

### DIFF
--- a/cmd/alert-publisher/hash.go
+++ b/cmd/alert-publisher/hash.go
@@ -1,0 +1,60 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains the functions to calculate the hashes fo alerts.
+
+package main
+
+import (
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"io"
+	"sort"
+
+	monitoring "github.com/jhernand/openshift-monitoring/pkg/apis/monitoring/v1alpha1"
+)
+
+// hashAlert calculates the hash for the given alert.
+//
+func hashAlert(alert *monitoring.Alert) string {
+	dst := fnv.New32a()
+	hashMap(alert.Status.Labels, dst)
+	io.WriteString(dst, "\n")
+	hashMap(alert.Status.Annotations, dst)
+	sum := dst.Sum32()
+	return fmt.Sprintf("%d", sum)
+}
+
+// hashMap writes the keys and values of a map to a hash, making sure that they are in order to
+// that the result will allways be the same regardless of the internal ordering of the map.
+//
+func hashMap(src map[string]string, dst hash.Hash) {
+	keys := make([]string, len(src))
+	i := 0
+	for key, _ := range src {
+		keys[i] = key
+		i++
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		value := src[key]
+		io.WriteString(dst, key)
+		io.WriteString(dst, "=")
+		io.WriteString(dst, value)
+		io.WriteString(dst, "\n")
+	}
+}

--- a/pkg/alertmanager/data.go
+++ b/pkg/alertmanager/data.go
@@ -20,11 +20,20 @@ import (
 	"time"
 )
 
+// AlertStatus represents the status of a alert.
+//
+type AlertStatus string
+
+const (
+	AlertStatusFiring   AlertStatus = "firing"
+	AlertStatusResolved AlertStatus = "resolved"
+)
+
 // Data represents each message sent by the alert manager to a receiver.
 //
 type Message struct {
 	Receiver          string            `json:"receiver,omitempty"`
-	Status            string            `json:"status,omitempty"`
+	Status            AlertStatus       `json:"status,omitempty"`
 	Alerts            []*Alert          `json:"alerts,omitempty"`
 	GroupLabels       map[string]string `json:"groupLabels,omitempty"`
 	CommonLabels      map[string]string `json:"commonLabels,omitempty"`
@@ -35,7 +44,7 @@ type Message struct {
 // Alert represents each of the alerts sent by the alert manager to a receiver.
 //
 type Alert struct {
-	Status       string            `json:"status,omitempty"`
+	Status       AlertStatus       `json:"status,omitempty"`
 	Labels       map[string]string `json:"labels,omitempty"`
 	Annotations  map[string]string `json:"annotations,omitempty"`
 	StartsAt     time.Time         `json:"startsAt,omitempty"`

--- a/pkg/labels/doc.go
+++ b/pkg/labels/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This package contains funtions to manipulate the labels used for monitoring.
+//
+package labels

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -1,0 +1,31 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package labels
+
+import (
+	"fmt"
+)
+
+// The prefix used by monitoring labels.
+//
+const Prefix = "monitoring.openshift.io"
+
+// Some frequently used label names.
+//
+var (
+	Hash = fmt.Sprintf("%s/hash", Prefix)
+)


### PR DESCRIPTION
Thi pull requests changes the alert publisher so that it generates unique
alert names.

It also changes the alert publisher so that it deletes the Kubernetes `Alert` objects
when alerts are resolved.